### PR TITLE
Bump log4j-core from 2.11.0 to 2.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.0</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Bumps log4j-core from 2.11.0 to 2.13.2.

Signed-off-by: dependabot[bot] <support@github.com>